### PR TITLE
Add `--insecure-skip-verify` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Usage:
 
 Flags:
   -h, --help                      help for query
+  -k, --insecure-skip-verify      allow insecure server connections (e.g. self-signed TLS certificates)
       --resolver-addr string      address of a DNS resolver to use for resolving DoH server names (e.g. 8.8.8.8:53)
       --resolver-network string   protocol to use for resolving DoH server names (e.g. udp, tcp) (default "udp")
       --retry-max int             maximum number of retries for each query (default 10)

--- a/internal/cli/command_test.go
+++ b/internal/cli/command_test.go
@@ -46,7 +46,7 @@ func TestCommand(t *testing.T) {
 			},
 		},
 		{
-			name: "google.com",
+			name: "query google.com",
 			args: []string{"query", "google.com"},
 			check: func(t *testing.T, output io.Reader) {
 				b, err := io.ReadAll(output)
@@ -62,8 +62,24 @@ func TestCommand(t *testing.T) {
 			},
 		},
 		{
-			name: "cloudflare.com",
+			name: "query cloudflare.com",
 			args: []string{"query", "cloudflare.com"},
+			check: func(t *testing.T, output io.Reader) {
+				b, err := io.ReadAll(output)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if len(b) == 0 {
+					t.Fatal("got no output for known domain")
+				}
+
+				t.Log(string(b))
+			},
+		},
+		{
+			name: "insecurely query google.com",
+			args: []string{"query", "google.com", "--insecure-skip-verify"},
 			check: func(t *testing.T, output io.Reader) {
 				b, err := io.ReadAll(output)
 				if err != nil {


### PR DESCRIPTION
This PR aims to fix #39 so it is now possible to (insecurely) skip TLS server certificate verification when making DoH queries.

```console
$ doh query google.com --insecure-skip-verify --servers https://127.0.0.1:8080/dns-query
...
```

```console
$ doh query google.com -k --servers https://127.0.0.1:8080/dns-query
...
```

 This is somewhat useful for local DoH servers, but should generally be avoided for public servers.